### PR TITLE
Don't set startContainer directly

### DIFF
--- a/document-focus.js
+++ b/document-focus.js
@@ -3,8 +3,7 @@ exports.releaseDocumentFocus = function () {
   document.body.appendChild(element)
 
   const range = document.createRange()
-  range.startContainer = element
-  range.startOffset = 0
+  range.setStart(element, 0)
 
   const selection = window.getSelection()
   selection.removeAllRanges()


### PR DESCRIPTION
Attempts to set the `startContainer` throw

```
Uncaught TypeError: Cannot assign to read only property 'startContainer' of object '[object Range]'
```

Instead we'll use `range.setStart`.
